### PR TITLE
add read order

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -73,7 +73,28 @@ def list_orders():
 
 
 ######################################################################
+# RETRIEVE AN ORDER
+######################################################################
+@app.route("/orders/<int:order_id>", methods=["GET"])
+def get_orders(order_id):
+    """
+    Retrieve a single Order
+
+    This endpoint will return an Order based on it's id
+    """
+    app.logger.info("Request for Order with id: %s", order_id)
+
+    # See if the order exists and abort if it doesn't
+    order = Order.find(order_id)
+    if not order:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Order with id '{order_id}' could not be found.",
+        )
+
+    return jsonify(order.serialize()), status.HTTP_200_OK
+
+
+######################################################################
 #  R E S T   A P I   E N D P O I N T S
 ######################################################################
-
-# Todo: Place your REST API code here ...

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -27,6 +27,8 @@ from unittest.mock import patch
 from wsgi import app
 from service.models import Order, OrderItem, DataValidationError, db
 from tests.factories import OrderFactory, OrderItemFactory
+from datetime import datetime, timedelta
+
 
 DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
@@ -97,3 +99,29 @@ class TestOrder(TestCase):
         fresh = Order.find(order.id)
         self.assertEqual(len(fresh.orderitem), 3)
         self.assertEqual(str(fresh.total_amount), "19.48")
+
+    def test_read_order(self):
+        """It should Read an order"""
+        fake_order = OrderFactory()
+        fake_order.create()
+        db.session.refresh(fake_order)
+
+        # Read it back
+        found_order = Order.find(fake_order.id)
+
+        self.assertIsNotNone(found_order)
+        self.assertEqual(found_order.id, fake_order.id)
+        self.assertEqual(found_order.customer_id, fake_order.customer_id)
+        self.assertEqual(found_order.status, fake_order.status)
+        self.assertEqual(found_order.created_at, fake_order.created_at)
+        self.assertEqual(found_order.updated_at, fake_order.updated_at)
+        self.assertLessEqual(
+            abs(found_order.updated_at - found_order.created_at), timedelta(seconds=1)
+        )
+        self.assertEqual(found_order.total_amount, 0)
+        self.assertEqual(found_order.orderitem, [])
+
+    def test_read_order_not_found(self):
+        """It should return None when the order id does not exist"""
+        missing_id = 99999999  # unlikely to exist
+        self.assertIsNone(Order.find(missing_id))


### PR DESCRIPTION
- added `GET/orders/<int:order_id>` for order
- Add db level and API level tests for reading orders (happy + not-found)
- revised the helper create functions in `test_routes.py`