### PR TITLE
added read orderitem

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -139,6 +139,44 @@ def create_orders():
     return jsonify(message), status.HTTP_201_CREATED, {"Location": location_url}
 
 
+#############################################################################
+# RETRIEVE AN ORDERITEM FROM ORDER
+######################################################################
+@app.route("/orders/<int:order_id>/orderitems/<int:orderitem_id>", methods=["GET"])
+def get_orderitems(order_id, orderitem_id):
+    """
+    Get an OrderItem
+
+    This endpoint returns just an orderitem
+    """
+    app.logger.info(
+        "Request to retrieve OrderItem %s for Order id: %s", orderitem_id, order_id
+    )
+
+    # See if the orderitem exists and abort if it doesn't
+    order = Order.find(order_id)
+    if not order:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Order with id '{order_id}' could not be found.",
+        )
+
+    # See if the orderitem exists and abort if it doesn't
+    orderitem = OrderItem.find(orderitem_id)
+    if not orderitem:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"OrderItem with id '{orderitem_id}' could not be found.",
+        )
+    if orderitem.order_id != order_id:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"OrderItem '{orderitem_id}' does not belong to Order '{order_id}'.",
+        )
+
+    return jsonify(orderitem.serialize()), status.HTTP_200_OK
+
+
 ######################################################################
 #  U T I L I T Y   F U N C T I O N S
 ######################################################################
@@ -160,5 +198,3 @@ def check_content_type(content_type):
     abort(
         status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, f"Content-Type must be {content_type}"
     )
-#  R E S T   A P I   E N D P O I N T S
-######################################################################

--- a/tests/test_orderitem.py
+++ b/tests/test_orderitem.py
@@ -106,6 +106,32 @@ class TestOrder(TestCase):
         self.assertEqual(len(fresh.orderitem), 1)
         self.assertEqual(str(fresh.orderitem[0].line_amount), "37.50")  # 12.50 * 3
 
+    def test_read_orderitem(self):
+        """It should Read an orderitem"""
+
+        orders = Order.all()
+        self.assertEqual(orders, [])
+        order = OrderFactory()
+        orderitem = OrderItemFactory(order=order)
+        order.orderitem.append(orderitem)
+        order.create()
+
+        # Read it back
+        found_order = Order.find(order.id)
+        self.assertIsNotNone(found_order)
+
+        items = OrderItem.find_by_order_id(found_order.id)
+        self.assertEqual(len(items), 1)
+        found_orderitem = items[0]
+
+        self.assertIsNotNone(found_orderitem)
+        self.assertEqual(found_orderitem.id, orderitem.id)
+        self.assertEqual(found_orderitem.order_id, orderitem.order_id)
+        self.assertEqual(found_orderitem.product_id, orderitem.product_id)
+        self.assertEqual(found_orderitem.price, orderitem.price)
+        self.assertEqual(found_orderitem.quantity, orderitem.quantity)
+        self.assertEqual(found_orderitem.line_amount, orderitem.line_amount)
+
     def test_serialize_an_orderitem(self):
         """It should Serialize an orderitem"""
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -155,3 +155,40 @@ class TestOrderService(TestCase):
     ######################################################################
     #  O R D E R I T E M  T E S T   C A S E S
     ######################################################################
+    def test_get_orderitem(self):
+        """It should Get an orderitem from an order"""
+        # create a known orderitem
+        order = self._create_orders(1)[0]
+        orderitem = OrderItemFactory()
+        resp = self.client.post(
+            f"{BASE_URL}/{order.id}/orderitems",
+            json=orderitem.serialize(),
+            content_type="application/json",
+        )
+
+        # If the POST endpoint hasn't been merged yet, this will fail with 404.
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        self.assertIn("Location", resp.headers)
+
+        data = resp.get_json()
+        logging.debug(data)
+
+        self.assertIsNotNone(data, "Response is not JSON")
+        self.assertIn("id", data, f"JSON has no 'id': {data}")
+
+        orderitem_id = data["id"]
+
+        # retrieve it back
+        resp = self.client.get(
+            f"{BASE_URL}/{order.id}/orderitems/{orderitem_id}",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        data = resp.get_json()
+        logging.debug(data)
+        self.assertEqual(data["order_id"], order.id)
+        self.assertEqual(data["product_id"], orderitem.product_id)
+        self.assertEqual(data["price"], str(orderitem.price))
+        self.assertEqual(data["quantity"], str(orderitem.quantity))
+        self.assertEqual(data["line_amount"], str(orderitem.line_amount))


### PR DESCRIPTION
- Implement GET /orders/<order_id>/orderitems/<orderitem_id> to retrieve a single OrderItem
- Validate order existence and ownership (404 if item not found or does not belong to order)
- Add tests at both DB (model) and API levels