### PR TITLE
add DELETE /orders/<id> endpoint

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -168,6 +168,28 @@ def update_orders(order_id):
 
 
 ######################################################################
+# DELETE AN ORDER
+######################################################################
+@app.route("/orders/<int:order_id>", methods=["DELETE"])
+def delete_orders(order_id):
+    """
+    Delete an Order
+
+    This endpoint will delete an Order based the id specified in the path
+    """
+    app.logger.info("Request to Delete an order with id [%s]", order_id)
+
+    # Delete the Order if it exists
+    order = Order.find(order_id)
+    if order:
+        app.logger.info("Order with ID: %d found.", order.id)
+        order.delete()
+
+    app.logger.info("Order with ID: %d delete complete.", order_id)
+    return {}, status.HTTP_204_NO_CONTENT
+
+
+######################################################################
 # ADD AN ORDERITEM TO AN ORDER
 ######################################################################
 @app.route("/orders/<int:order_id>/orderitems", methods=["POST"])

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -126,7 +126,7 @@ class TestOrder(TestCase):
         same_order = Order.find_by_customer_id(order.customer_id)[0]
         self.assertEqual(same_order.id, order.id)
         self.assertEqual(same_order.customer_id, order.customer_id)
-    
+
     def test_read_order(self):
         """It should Read an order"""
         fake_order = OrderFactory()
@@ -152,6 +152,15 @@ class TestOrder(TestCase):
         """It should return None when the order id does not exist"""
         missing_id = 99999999  # unlikely to exist
         self.assertIsNone(Order.find(missing_id))
+
+    def test_delete_an_order(self):
+        """It should Delete an Order"""
+        order = OrderFactory()
+        order.create()
+        self.assertEqual(len(Order.all()), 1)
+        # delete the order and make sure it isn't in the database
+        order.delete()
+        self.assertEqual(len(Order.all()), 0)
 
     def test_serialize_an_order(self):
         """It should Serialize an order"""
@@ -230,3 +239,17 @@ class TestOrder(TestCase):
         exception_mock.side_effect = Exception()
         order = OrderFactory()
         self.assertRaises(DataValidationError, order.update)
+
+
+######################################################################
+#  T E S T   E X C E P T I O N   H A N D L E R S
+######################################################################
+class TestExceptionHandlers(TestCase):
+    """Order Model Exception Handlers"""
+
+    @patch("service.models.db.session.commit")
+    def test_delete_exception(self, exception_mock):
+        """It should catch a delete exception"""
+        exception_mock.side_effect = Exception()
+        order = OrderFactory()
+        self.assertRaises(DataValidationError, order.delete)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -187,6 +187,22 @@ class TestOrderService(TestCase):
         updated = resp.get_json()
         self.assertEqual(updated["status"], "SHIPPED")
 
+    def test_delete_order(self):
+        """It should Delete an Order"""
+        test_order = self._create_orders(1)[0]
+        response = self.client.delete(f"{BASE_URL}/{test_order.id}")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(len(response.data), 0)
+        # make sure they are deleted
+        response = self.client.get(f"{BASE_URL}/{test_order.id}")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_delete_non_existing_order(self):
+        """It should Delete an Order even if it doesn't exist"""
+        response = self.client.delete(f"{BASE_URL}/0")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(len(response.data), 0)
+
     ######################################################################
     #  O R D E R I T E M  T E S T   C A S E S
     ######################################################################


### PR DESCRIPTION
Author: @YeyuChia 
Merged by: @leahli-nyu 
Original PR: https://github.com/CSCI-GA-2820-FA25-001/orders/pull/41
-----------------------------
Author:

Made the following changes:
-Added delete order endpoint in 'routes.py'
-Added test case for delete endpoint

