### PR TITLE
query params added to get order

### DIFF
--- a/service/common/order_status.py
+++ b/service/common/order_status.py
@@ -1,0 +1,14 @@
+"""
+Common Status Enum for Order Service
+"""
+
+from enum import Enum
+
+class Status(Enum):
+    """Enumeration of valid Order Statuses"""
+    CREATED = 0
+    PAID = 1
+    CANCELED = 2
+    SHIPPED = 3
+    FULFILLED = 4
+    REFUNDED = 5

--- a/service/models/order.py
+++ b/service/models/order.py
@@ -8,7 +8,7 @@ from decimal import Decimal, InvalidOperation
 from datetime import datetime
 from .persistent_base import db, PersistentBase, DataValidationError
 from .orderitem import OrderItem
-
+from service.common.order_status import Status
 
 logger = logging.getLogger("flask.app")
 
@@ -17,15 +17,7 @@ logger = logging.getLogger("flask.app")
 ######################################################################
 
 
-class Status(Enum):
-    """Enumeration of valid Order Statuses"""
 
-    CREATED = 0
-    PAID = 1
-    CANCELED = 2
-    SHIPPED = 3
-    FULFILLED = 4
-    REFUNDED = 5
 
 
 class Order(db.Model, PersistentBase):

--- a/service/routes.py
+++ b/service/routes.py
@@ -20,10 +20,11 @@ Order and OrderItem Service
 This microservice handles the lifecycle of Orders and OrderItems
 """
 from flask import jsonify, request, url_for, abort
-from flask import current_app as app  # Import Flask application
+from flask import current_app as app
 from service.models import Order, OrderItem
 from service.common import status  # HTTP Status Codes
-from service.common import status as http_status
+from service.common.order_status import Status
+from datetime import datetime, timedelta
 
 
 ######################################################################
@@ -94,7 +95,7 @@ def list_orders():
     customer_id = request.args.get("customer_id")
     created_at = request.args.get("created_at")
 
-    query= Order.query
+    query = Order.query
 
     if status_arg:
         try:
@@ -102,7 +103,7 @@ def list_orders():
             query = query.filter(Order.status == status_enum)
         except KeyError:
             abort(
-                http_status.HTTP_400_BAD_REQUEST,
+                status.HTTP_400_BAD_REQUEST,  # Use status (HTTP) not http_status
                 f"Unknown status '{status_arg}'. Valid statuses: {[s.name for s in Status]}",
             )
 
@@ -114,7 +115,7 @@ def list_orders():
             dt = datetime.fromisoformat(created_at)
         except ValueError:
             abort(
-                http_status.HTTP_400_BAD_REQUEST,
+                status.HTTP_400_BAD_REQUEST,  # Use status (HTTP)
                 "Invalid date format for created_at. Use ISO 8601 like '2025-10-20' or '2025-10-20T15:30:00'.",
             )
 
@@ -124,13 +125,10 @@ def list_orders():
             query = query.filter(Order.created_at >= start, Order.created_at < end)
         else:
             query = query.filter(Order.created_at == dt)    
-            
-                        
 
     orders = query.all()
     results = [order.serialize() for order in orders]
-    return jsonify(results), http_status.HTTP_200_OK
-
+    return jsonify(results), status.HTTP_200_OK  # Use status (HTTP)
 
 ######################################################################
 # RETRIEVE AN ORDER

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -24,7 +24,9 @@ from wsgi import app
 from tests.factories import OrderFactory, OrderItemFactory
 from service.common import status  # HTTP Status Codes
 from service.models import db, Order
-from service.common import status as http_status
+from service.common import status 
+from datetime import datetime
+from service.common.order_status import Status
 
 DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
@@ -203,7 +205,60 @@ class TestOrderService(TestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(len(response.data), 0)
 
-    from datetime import datetime
+    def test_get_orders_by_status(self):
+        """GET /orders?status=SHIPPED returns only SHIPPED orders"""
+        o1 = OrderFactory()
+        o1.status = Status.SHIPPED
+        resp = self.client.post(BASE_URL, json=o1.serialize())
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        o2 = OrderFactory()
+        o2.status = Status.CREATED
+        resp = self.client.post(BASE_URL, json=o2.serialize())
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        resp = self.client.get(BASE_URL, query_string="status=SHIPPED")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertTrue(all(item["status"] == "SHIPPED" for item in data))
+
+    def test_get_orders_by_customer_id(self):
+        """GET /orders?customer_id=101 returns that customer's orders"""
+        o1 = OrderFactory()
+        o1.customer_id = "101"
+        resp = self.client.post(BASE_URL, json=o1.serialize())
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        o2 = OrderFactory()
+        o2.customer_id = "202"
+        resp = self.client.post(BASE_URL, json=o2.serialize())
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        resp = self.client.get(BASE_URL, query_string="customer_id=101")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertTrue(all(d["customer_id"] == "101" for d in data))
+
+    def test_get_orders_by_created_at(self):
+        """GET /orders?created_at=YYYY-MM-DD returns orders for that day"""
+        # create two orders on different days
+        o1 = OrderFactory()
+        o1.created_at = datetime(2020, 1, 10, 9, 0, 0)
+        resp = self.client.post(BASE_URL, json=o1.serialize())
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        o2 = OrderFactory()
+        o2.created_at = datetime(2020, 1, 11, 9, 0, 0)
+        resp = self.client.post(BASE_URL, json=o2.serialize())
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        resp = self.client.get(BASE_URL, query_string="created_at=2020-01-10")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(len(data), 1)
+        self.assertTrue(data[0]["created_at"].startswith("2020-01-10"))
+    
+
     
 
     ######################################################################


### PR DESCRIPTION
## 🚀 Feature: Query Parameter Filtering for Orders API

### Changes Made
- Added query parameter support for filtering orders by `status`, `customer_id`, and `created_at`

### API Usage
```http
GET /orders?status=shipped
GET /orders?customer_id=12345
GET /orders?created_at=2024-01-15
GET /orders?status=created&customer_id=12345